### PR TITLE
fix: version-check crash on Terraform provider constraint (~>3.0)

### DIFF
--- a/.jenkins/version-check.Jenkinsfile
+++ b/.jenkins/version-check.Jenkinsfile
@@ -689,9 +689,17 @@ EOF
   }
 }
 
+// Helper: parse major version from a string that may be a constraint (e.g. "~>3.0") or plain semver ("4.58.0")
+def parseMajorVersion(String v) {
+  if (!v?.trim()) return 0
+  def cleaned = v.replaceAll(/^[^0-9]+/, '').trim()  // strip constraint prefix like ~> >= =
+  def segment = cleaned.split('\\.')[0]?.trim()
+  return (segment ==~ /[0-9]+/) ? segment.toInteger() : 0
+}
+
 // Helper function to determine if version update is major
 def isMajorVersionUpdate(current, latest) {
-  def currentMajor = current.split('\\.')[0].toInteger()
-  def latestMajor = latest.split('\\.')[0].toInteger()
+  def currentMajor = parseMajorVersion(current?.toString())
+  def latestMajor = parseMajorVersion(latest?.toString())
   return latestMajor > currentMajor
 }


### PR DESCRIPTION
  Fixes #7
  Normalizes Terraform version strings (e.g. ~>3.0) before major-version comparison so the job no longer throws NumberFormatException.
  ...

This pull request improves the version-checking logic in the `.jenkins/version-check.Jenkinsfile` by making the major version parsing more robust. The changes ensure that version strings with constraint prefixes (like `~>3.0` or `>=4.2.1`) are handled correctly when determining if an update is a major version change.

Version parsing improvements:

* Added a new helper function `parseMajorVersion` to extract the major version number from version strings that may include constraint prefixes, making the logic more reliable for a wider variety of version formats.
* Updated the `isMajorVersionUpdate` function to use `parseMajorVersion` for both current and latest versions, improving accuracy in major version comparisons.