### PR TITLE
fix(jenkins): ensure git runs in WORKSPACE for PR creation

### DIFF
--- a/.jenkins/version-check.Jenkinsfile
+++ b/.jenkins/version-check.Jenkinsfile
@@ -430,8 +430,8 @@ spec:
               
               sh '''
                 # Ensure we run git operations inside the checked-out workspace
-                if [ -n "${WORKSPACE:-}" ]; then
-                  cd "${WORKSPACE}"
+                if [ -n "$WORKSPACE" ]; then
+                  cd "$WORKSPACE" || { echo "Failed to change to workspace directory: $WORKSPACE"; exit 1; }
                 fi
                 if [ ! -d .git ]; then
                   echo "Workspace is not a git repository: $(pwd)"


### PR DESCRIPTION
Fixes #11

------
Jenkins sometimes runs the PR-creation shell step outside the repo, which causes `git config` to fail with "fatal: not in a git directory".

CD into $WORKSPACE and assert .git exists before running any git commands.