### PR TITLE
Align Jenkins Terraform plan inputs

### DIFF
--- a/.jenkins/README.md
+++ b/.jenkins/README.md
@@ -15,6 +15,12 @@ Validates Terraform infrastructure code using **Azure Workload Identity** for au
 
 **Note**: The pipeline uses `terraform.tfvars.example` for CI validation (placeholder values). Real secrets are never stored in blob storage or git.
 
+**Plan parity with Cloud Shell**: Set non-secret TF_VARs so CI plans match production inputs:
+- `TF_VAR_jenkins_graceful_disconnect_url`
+- `TF_VAR_jenkins_graceful_disconnect_user`
+- `TF_VAR_jenkins_graceful_disconnect_agent_name`
+- `ARM_SUBSCRIPTION_ID` (required for Azure auth)
+
 ### `helm-validation.Jenkinsfile`
 Validates Helm charts and Kubernetes manifests:
 - Helm template rendering

--- a/.jenkins/terraform-validation.Jenkinsfile
+++ b/.jenkins/terraform-validation.Jenkinsfile
@@ -10,6 +10,11 @@ pipeline {
     STORAGE_ACCOUNT = 'tfcaneprostate1'
     STORAGE_CONTAINER = 'tfstate'
     TFVARS_BLOB = 'terraform.tfvars'
+
+    // Non-secret defaults so CI plan matches Cloud Shell (override in job config if needed)
+    TF_VAR_jenkins_graceful_disconnect_url = "${env.TF_VAR_jenkins_graceful_disconnect_url ?: 'https://jenkins-oke.canepro.me'}"
+    TF_VAR_jenkins_graceful_disconnect_user = "${env.TF_VAR_jenkins_graceful_disconnect_user ?: 'admin'}"
+    TF_VAR_jenkins_graceful_disconnect_agent_name = "${env.TF_VAR_jenkins_graceful_disconnect_agent_name ?: 'aks-agent'}"
   }
   
   stages {

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -362,6 +362,11 @@ Jenkins runs these stages on every push/PR to validate Terraform code:
 
 **Authentication**: Uses Azure Workload Identity via the `jenkins` service account federated to the ESO managed identity.
 
+**Plan parity**: To make Jenkins plans match Cloud Shell results, set non-secret TF_VARs in the job:
+- `TF_VAR_jenkins_graceful_disconnect_url`
+- `TF_VAR_jenkins_graceful_disconnect_user`
+- `TF_VAR_jenkins_graceful_disconnect_agent_name`
+
 **View CI Results**:
 - Jenkins: `https://jenkins.canepro.me/job/rocketchat-k8s/job/master/`
 - Plan output is archived as a build artifact


### PR DESCRIPTION
## Summary
- set non-secret TF_VAR defaults in `.jenkins/terraform-validation.Jenkinsfile` so CI plans match Cloud Shell
- document CI plan parity requirements in `.jenkins/README.md` and `OPERATIONS.md`

## Testing
- not run (Jenkins will validate on push)

## Notes
- Defaults can be overridden in Jenkins job configuration if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Jenkins CI and operations documentation to explain plan parity between CI and Cloud Shell environments.

* **Chores**
  * Added configuration variables to Jenkins CI to ensure consistent Terraform planning results across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->