### PR TITLE
fix(ops): create logs-viewer assets ConfigMap via Argo replace

### DIFF
--- a/ops/manifests/logs-viewer-web-assets-configmap.yaml
+++ b/ops/manifests/logs-viewer-web-assets-configmap.yaml
@@ -2652,5 +2652,7 @@ data:
 
 kind: ConfigMap
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true
   name: logs-viewer-web-assets
   namespace: rocketchat


### PR DESCRIPTION
Why
The logs-viewer-web-assets ConfigMap is large enough that client-side apply fails with metadata.annotations too long.
Argo then creates deployment/service but not this ConfigMap, leaving the pod stuck in ContainerCreating with configmap not found.

What
- Add argocd.argoproj.io/sync-options: Replace=true to logs-viewer-web-assets ConfigMap.

Validation
- kubectl create --dry-run=server -f ops/manifests/logs-viewer-web-assets-configmap.yaml succeeds.
- kubectl kustomize ops renders successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration settings for enhanced operational synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->