### PR TITLE
fix(ops): preserve HTTPS origin for /logs-viewer redirect

### DIFF
--- a/ops/manifests/logs-viewer-web-nginx-configmap.yaml
+++ b/ops/manifests/logs-viewer-web-nginx-configmap.yaml
@@ -17,7 +17,7 @@ data:
       }
 
       location = /logs-viewer {
-        return 301 /logs-viewer/;
+        return 301 https://$host/logs-viewer/;
       }
 
       location /logs-viewer/ {


### PR DESCRIPTION
Problem
/logs-viewer currently redirects to backend port (http://k8.canepro.me:8080/logs-viewer/) behind ingress.

Fix
- Change nginx exact-path redirect to: return 301 https://$host/logs-viewer/;

Validation
- kubectl kustomize ops renders successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated redirect behavior for the logs-viewer endpoint to use absolute HTTPS URLs instead of relative paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->