### PR TITLE
fix(ops): roll logs-viewer pod after nginx config update

### DIFF
--- a/ops/manifests/logs-viewer-web-deployment.yaml
+++ b/ops/manifests/logs-viewer-web-deployment.yaml
@@ -12,6 +12,8 @@ spec:
       app.kubernetes.io/name: logs-viewer-web
   template:
     metadata:
+      annotations:
+        canepro.me/logs-viewer-nginx-rev: "2026-02-27-01"
       labels:
         app.kubernetes.io/name: logs-viewer-web
     spec:


### PR DESCRIPTION
Why
The nginx ConfigMap update is already in-cluster, but nginx only reads config at startup.
We need a pod template change so Argo triggers rollout and new redirect behavior is picked up.

What
- Add pod template annotation canepro.me/logs-viewer-nginx-rev: "2026-02-27-01".

Validation
- kubectl kustomize ops renders successfully.