### PR TITLE
fix(ops): serve logs-viewer assets from flattened ConfigMap mount

### DIFF
--- a/ops/manifests/logs-viewer-web-nginx-configmap.yaml
+++ b/ops/manifests/logs-viewer-web-nginx-configmap.yaml
@@ -20,6 +20,13 @@ data:
         return 301 https://$host/logs-viewer/;
       }
 
+      # ConfigMap mounts flatten keys at /usr/share/nginx/html, so built assets
+      # requested as /logs-viewer/assets/* must map to /* at runtime.
+      location /logs-viewer/assets/ {
+        rewrite ^/logs-viewer/assets/(.*)$ /$1 break;
+        try_files $uri =404;
+      }
+
       location /logs-viewer/ {
         rewrite ^/logs-viewer/(.*)$ /$1 break;
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Issue
Open Logs Viewer showed a blank page. Browser console reported module/style blocked by MIME type text/html.

Root cause
Deployment now mounts full ConfigMap without items, which flattens keys into /usr/share/nginx/html.
But Vite index requests /logs-viewer/assets/* paths. Existing nginx rewrite mapped to /assets/* and then fell back to index.html, returning HTML for JS/CSS URLs.

Fix
- Add dedicated nginx location for /logs-viewer/assets/ that rewrites to /<filename> and try_files $uri =404.
- Keep existing SPA fallback for /logs-viewer/ routes.

Validation
- kubectl kustomize ops renders successfully.
- Reproduced console MIME errors before fix via Playwright.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed asset delivery for the logs viewer interface to ensure static resources load correctly
  * Improved URL path handling for asset requests to properly resolve missing files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->