### PR TITLE
fix(ops): rollout logs-viewer after nginx assets rewrite

### DIFF
--- a/ops/manifests/logs-viewer-web-deployment.yaml
+++ b/ops/manifests/logs-viewer-web-deployment.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        canepro.me/logs-viewer-nginx-rev: "2026-02-27-01"
+        canepro.me/logs-viewer-nginx-rev: "2026-02-27-02"
       labels:
         app.kubernetes.io/name: logs-viewer-web
     spec:


### PR DESCRIPTION
Why
Nginx config is mounted via subPath, so ConfigMap changes require pod restart to take effect.

What
- Bump logs-viewer pod template annotation to force rollout.

Validation
- kubectl kustomize ops renders successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->