### PR TITLE
fix: capture direct Jenkins bridge excerpts

### DIFF
--- a/.jenkins/README.md
+++ b/.jenkins/README.md
@@ -123,6 +123,20 @@ To register Jenkins failures in PipelineHealer, prefer the same GitOps path used
 
 If these credentials are absent, the Jenkinsfiles skip bridge notification and continue with the existing GitHub issue/comment behavior. Manual Jenkins UI credentials are only a fallback.
 
+### Recommended bridge capture pattern
+
+Bridge-enabled Jenkinsfiles should capture the actual failing shell output into `${WORKSPACE}/.pipelinehealer-log-excerpt.txt` with `.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh` and then export `PH_LOG_EXCERPT_FILE` from the `post { failure { ... } }` block before calling `send-pipelinehealer-bridge.sh`.
+
+This is the supported pattern because it:
+- does not depend on Jenkins-specific plugins such as `tee`
+- does not require `currentBuild.rawBuild` or extra script approvals
+- works on the static `aks-agent` and on Kubernetes agents
+
+For any bridge-enabled pipeline:
+- keep workspace cleanup in `post { cleanup { ... } }`, not `post { always { ... } }`, so failure handling still has access to the checked-out scripts and captured excerpt
+- wrap the failure-prone `sh` steps that do the real validation or scanning work
+- keep the existing signed bridge sender as the only POST implementation
+
 ### CLI setup (when UI is painful)
 Use the repo script which handles CSRF + session cookies. Create `github-token` on the target Jenkins first.
 

--- a/.jenkins/SETUP_AUTOMATED_JOBS.md
+++ b/.jenkins/SETUP_AUTOMATED_JOBS.md
@@ -33,6 +33,17 @@ The scheduled jobs are declared in `jenkins-values.yaml` and should be reconcile
 
 ArgoCD sync of the Jenkins release is the preferred way to create or update them.
 
+### PipelineHealer bridge behavior
+
+When `pipelinehealer-bridge-url` and `pipelinehealer-bridge-secret` are present in Jenkins, the scheduled jobs also send signed failure events to PipelineHealer.
+
+The supported capture path is repo-managed and plugin-free:
+- validation stages write the latest failure excerpt to `${WORKSPACE}/.pipelinehealer-log-excerpt.txt`
+- failure handlers export `PH_LOG_EXCERPT_FILE`
+- cleanup happens in `post { cleanup { ... } }` so the excerpt and bridge scripts still exist during failure handling
+
+If the bridge credentials are missing, the jobs continue with the existing GitHub issue/comment behavior only.
+
 ### Option 2: Using Setup Scripts (Fallback)
 
 ```bash

--- a/.jenkins/central-observability-hub-stack-k8s-manifest-validation.Jenkinsfile
+++ b/.jenkins/central-observability-hub-stack-k8s-manifest-validation.Jenkinsfile
@@ -34,6 +34,7 @@ pipeline {
     stage('ArgoCD App Validation') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Validate each ArgoCD Application manifest
           # These are the GitOps control plane definitions
           for app in argocd/applications/*.yaml; do
@@ -42,6 +43,7 @@ pipeline {
               kubeconform -strict "$app" || exit 1
             fi
           done
+SCRIPT
         '''
       }
     }
@@ -53,6 +55,7 @@ pipeline {
       steps {
         dir('helm') {
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             # Find all Helm chart directories with values.yaml
             for chart_dir in */; do
               if [ -f "${chart_dir}values.yaml" ]; then
@@ -63,6 +66,7 @@ pipeline {
                 kubeconform -strict /tmp/"$chart_name"-manifests.yaml || exit 1
               fi
             done
+SCRIPT
           '''
         }
       }
@@ -74,6 +78,7 @@ pipeline {
     stage('K8s Manifest Validation') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Validate raw Kubernetes manifests (non-Helm)
           # These are typically Ingress, ConfigMaps, Secrets, etc.
           if [ -d "k8s" ]; then
@@ -84,6 +89,7 @@ pipeline {
               fi
             done
           fi
+SCRIPT
         '''
       }
     }
@@ -94,6 +100,7 @@ pipeline {
     stage('YAML Lint') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Install yamllint if not available
           apk add --no-cache yamllint || true
           
@@ -106,13 +113,14 @@ pipeline {
           # Lint raw Kubernetes manifests
           yamllint -c .yamllint.yaml k8s/ || true
           # || true: warnings don't fail build, only errors
+SCRIPT
         '''
       }
     }
   }
   
   post {
-    always {
+    cleanup {
       cleanWs()
     }
     success {
@@ -137,6 +145,9 @@ pipeline {
               export PH_FAILURE_STAGE="k8s-manifest-validation"
               export PH_FAILURE_SUMMARY="Jenkins central observability manifest validation failed"
               export PH_RESULT="FAILURE"
+              if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
+                export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+              fi
               bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
                 echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
             '''

--- a/.jenkins/central-observability-hub-stack-terraform-validation.Jenkinsfile
+++ b/.jenkins/central-observability-hub-stack-terraform-validation.Jenkinsfile
@@ -48,9 +48,11 @@ pipeline {
     stage('Terraform Format Check') {
       steps {
         dir('terraform') {
-          // -check: only check, don't modify files
-          // -recursive: check all subdirectories
-          sh 'terraform fmt -check -recursive'
+          sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+            terraform fmt -check -recursive
+SCRIPT
+          '''
         }
       }
     }
@@ -60,10 +62,12 @@ pipeline {
     stage('Terraform Validate') {
       steps {
         dir('terraform') {
-          // -backend=false: no state file needed for validation
-          sh 'terraform init -backend=false'
-          // Validate configuration syntax
-          sh 'terraform validate'
+          sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+            terraform init -backend=false
+            terraform validate
+SCRIPT
+          '''
         }
       }
     }
@@ -93,7 +97,7 @@ pipeline {
   }
   
   post {
-    always {
+    cleanup {
       cleanWs()
     }
     success {
@@ -118,6 +122,9 @@ pipeline {
               export PH_FAILURE_STAGE="terraform-validation"
               export PH_FAILURE_SUMMARY="Jenkins central observability Terraform validation failed"
               export PH_RESULT="FAILURE"
+              if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
+                export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+              fi
               bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
                 echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
             '''

--- a/.jenkins/helm-validation.Jenkinsfile
+++ b/.jenkins/helm-validation.Jenkinsfile
@@ -29,6 +29,7 @@ pipeline {
     stage('Helm Template') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Render RocketChat Helm chart with values.yaml
           # Output: raw Kubernetes manifests for validation
           helm template rocketchat . -f values.yaml > /tmp/manifests.yaml
@@ -36,6 +37,7 @@ pipeline {
           # Render Traefik Helm chart (if traefik-values.yaml exists)
           # || true: don't fail if traefik-values.yaml doesn't exist (optional)
           helm template traefik . -f traefik-values.yaml > /tmp/traefik-manifests.yaml || true
+SCRIPT
         '''
       }
     }
@@ -47,7 +49,11 @@ pipeline {
       steps {
         // Validate both RocketChat and Traefik manifests
         // kubeconform checks: API versions, required fields, schema compliance
-        sh 'kubeconform -strict /tmp/manifests.yaml /tmp/traefik-manifests.yaml'
+        sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+          kubeconform -strict /tmp/manifests.yaml /tmp/traefik-manifests.yaml
+SCRIPT
+        '''
       }
     }
     
@@ -57,6 +63,7 @@ pipeline {
     stage('YAML Lint') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Install yamllint if not available in the agent image
           # || true: don't fail if yamllint is already installed
           apk add --no-cache yamllint || true
@@ -68,6 +75,7 @@ pipeline {
           # Lint Kubernetes manifests in ops/manifests/ directory
           # These are raw K8s manifests managed by Kustomize
           yamllint -c .yamllint.yaml ops/manifests/*.yaml || true
+SCRIPT
         '''
       }
     }
@@ -76,7 +84,7 @@ pipeline {
   // Post-build actions: cleanup and status reporting
   post {
     // Always clean workspace after build (free up disk space)
-    always {
+    cleanup {
       cleanWs()
     }
     // Success message for easy log scanning
@@ -103,6 +111,9 @@ pipeline {
               export PH_FAILURE_STAGE="helm-validation"
               export PH_FAILURE_SUMMARY="Jenkins Helm validation failed"
               export PH_RESULT="FAILURE"
+              if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
+                export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+              fi
               bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
                 echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
             '''

--- a/.jenkins/portfolio-website-main-application-validation.Jenkinsfile
+++ b/.jenkins/portfolio-website-main-application-validation.Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
     stage('Setup') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Install unzip (required by bun installer)
           # Update package list and install unzip if not already present
           if ! command -v unzip &> /dev/null; then
@@ -60,6 +61,7 @@ pipeline {
           export PATH="$HOME/.bun/bin:$PATH"
           # Verify installation
           bun --version
+SCRIPT
         '''
       }
     }
@@ -70,9 +72,11 @@ pipeline {
     stage('Install Dependencies') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           export PATH="$HOME/.bun/bin:$PATH"
           # Install project dependencies (Next.js, TypeScript, ESLint, etc.)
           bun install
+SCRIPT
         '''
       }
     }
@@ -83,10 +87,12 @@ pipeline {
     stage('Dependency Audit') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           export PATH="$HOME/.bun/bin:$PATH"
           # Run security audit on dependencies
           # || echo: don't fail on warnings, only critical vulnerabilities
           bun audit || echo "Audit completed (warnings may exist)"
+SCRIPT
         '''
       }
     }
@@ -97,11 +103,13 @@ pipeline {
     stage('Code Quality') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           export PATH="$HOME/.bun/bin:$PATH"
           # Run ESLint to catch code quality issues
           bun run lint
           # Check code formatting (Prettier) without modifying files
           bun run format:check
+SCRIPT
         '''
       }
     }
@@ -112,9 +120,11 @@ pipeline {
     stage('Type Checking') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           export PATH="$HOME/.bun/bin:$PATH"
           # Run TypeScript compiler in check-only mode
           bun run typecheck
+SCRIPT
         '''
       }
     }
@@ -125,10 +135,12 @@ pipeline {
     stage('Build Validation') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           export PATH="$HOME/.bun/bin:$PATH"
           # Build Next.js application for production
           # This validates that all code compiles and bundles correctly
           bun run build
+SCRIPT
         '''
       }
     }
@@ -145,6 +157,7 @@ pipeline {
       }
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           # Container scanning (if Dockerfile exists)
           # This would use tools like Trivy, Snyk, or similar
           if [ -f Dockerfile ]; then
@@ -152,6 +165,7 @@ pipeline {
             # Example: trivy image --exit-code 1 --severity HIGH,CRITICAL <image>
             # Note: Would need to build image first, then scan it
           fi
+SCRIPT
         '''
       }
     }
@@ -160,7 +174,7 @@ pipeline {
   // Post-build actions: cleanup and status reporting
   post {
     // Always clean workspace after build (free up disk space)
-    always {
+    cleanup {
       cleanWs()
     }
     // Success message for easy log scanning
@@ -187,6 +201,9 @@ pipeline {
               export PH_FAILURE_STAGE="application-validation"
               export PH_FAILURE_SUMMARY="Jenkins application validation failed"
               export PH_RESULT="FAILURE"
+              if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
+                export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+              fi
               bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
                 echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
             '''

--- a/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh
+++ b/.jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eu
+
+OUTPUT_FILE="${1:?usage: capture-pipelinehealer-bridge-excerpt.sh <output-file>}"
+CAPTURE_SHELL="${PH_CAPTURE_SHELL:-/bin/sh}"
+STATUS_FILE="$(mktemp)"
+SCRIPT_FILE="$(mktemp)"
+trap 'rm -f "$STATUS_FILE" "$SCRIPT_FILE"' EXIT
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+cat > "$SCRIPT_FILE"
+chmod +x "$SCRIPT_FILE"
+
+if [ ! -x "$CAPTURE_SHELL" ] && ! command -v "$CAPTURE_SHELL" >/dev/null 2>&1; then
+  echo "PipelineHealer bridge capture: shell not found: $CAPTURE_SHELL" >&2
+  exit 1
+fi
+
+(
+  set +e
+  "$CAPTURE_SHELL" "$SCRIPT_FILE" 2>&1
+  echo $? > "$STATUS_FILE"
+) | tee "$OUTPUT_FILE"
+
+STATUS="$(cat "$STATUS_FILE" 2>/dev/null || echo 1)"
+exit "$STATUS"

--- a/.jenkins/security-validation.Jenkinsfile
+++ b/.jenkins/security-validation.Jenkinsfile
@@ -30,6 +30,7 @@ pipeline {
     stage('Install Security Tools') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           set -e
           WORKDIR="${WORKSPACE:-$(pwd)}"
           export WORKDIR
@@ -111,6 +112,7 @@ pipeline {
           
           # Clean up old scan results to prevent accumulation across runs
           rm -f "$WORKDIR"/*.json "$WORKDIR"/*.txt "$WORKDIR"/*.md 2>/dev/null || true
+SCRIPT
         '''
       }
     }
@@ -120,12 +122,14 @@ pipeline {
       steps {
         dir('terraform') {
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             export PATH="${WORKSPACE}/checkov-venv/bin:${WORKSPACE}:${HOME:-/tmp}/.local/bin:${PATH}"
             # Run tfsec scan and output JSON results
             tfsec . --format json --out ${WORKSPACE}/${TFSEC_OUTPUT} || true
             
             # Also output human-readable format for logs
             tfsec . --format default || true
+SCRIPT
           '''
         }
       }
@@ -136,12 +140,14 @@ pipeline {
       steps {
         dir('terraform') {
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             export PATH="${WORKSPACE}/checkov-venv/bin:${WORKSPACE}:${HOME:-/tmp}/.local/bin:${PATH}"
             # Run checkov scan on Terraform files
             checkov -d . --framework terraform --output json --output-file ${WORKSPACE}/${CHECKOV_OUTPUT} || true
             
             # Also output CLI format for logs
             checkov -d . --framework terraform || true
+SCRIPT
           '''
         }
       }
@@ -151,6 +157,7 @@ pipeline {
     stage('Kubernetes Security Scan') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           export PATH="${WORKSPACE}/checkov-venv/bin:${WORKSPACE}:${PATH}"
           # Scan Kubernetes manifests in ops/manifests/
           if [ -d "ops/manifests" ] && command -v kube-score >/dev/null 2>&1; then
@@ -164,6 +171,7 @@ pipeline {
           if [ -f "/tmp/manifests.yaml" ]; then
             kube-score score /tmp/manifests.yaml --output-format json > helm-kube-score-results.json || true
           fi
+SCRIPT
         '''
       }
     }
@@ -206,6 +214,7 @@ pipeline {
               if (line.contains(':')) {
                 def image = line.trim()
                 sh """
+                  cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
                   export PATH="\${WORKSPACE}/checkov-venv/bin:\${WORKSPACE}:\${PATH}"
                   echo "Scanning image: ${image}"
                   VEX_ARG=""
@@ -214,6 +223,7 @@ pipeline {
                   fi
                   trivy image \${VEX_ARG} --format json --output ${WORKSPACE}/trivy-${image.replaceAll('[/: ]', '-')}.json ${image} || true
                   trivy image \${VEX_ARG} ${image} || true
+SCRIPT
                 """
               }
             }
@@ -230,6 +240,7 @@ pipeline {
         script {
           // Use jq so we don't depend on pipeline-utility-steps or script approvals.
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             set -e
             WORKDIR="${WORKSPACE:-$(pwd)}"
             export PATH="${WORKDIR}/checkov-venv/bin:${WORKDIR}:${HOME:-/tmp}/.local/bin:${PATH}"
@@ -296,6 +307,7 @@ EOF
               '{timestamp:$ts,critical:$critical,high:$high,medium:$medium,low:$low,risk_level:$risk,action_required:$action}' \
               > "${RISK_REPORT}"
             echo "Risk Assessment: $(cat "${RISK_REPORT}")"
+SCRIPT
           '''
 
           // Never fail the build due to findings
@@ -319,6 +331,7 @@ EOF
             }
             withEnv(["GITHUB_REPO=${env.GITHUB_REPO}"]) {
               sh '''
+                cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
                 set -e
                 WORKDIR="${WORKSPACE:-$(pwd)}"
                 export PATH="${WORKDIR}/checkov-venv/bin:${WORKDIR}:${HOME:-/tmp}/.local/bin:${PATH}"
@@ -532,6 +545,7 @@ EOF
                   -d @"$WORKDIR/security-issue-body.json" >/dev/null 2>&1; then
                   echo "⚠️ WARNING: Failed to create security findings issue"
                 fi
+SCRIPT
               '''
             }
           }
@@ -672,6 +686,9 @@ EOF
               export PH_FAILURE_STAGE="security-validation"
               export PH_FAILURE_SUMMARY="Scheduled Jenkins security validation failed"
               export PH_RESULT="FAILURE"
+              if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
+                export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+              fi
               bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
                 echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
             '''

--- a/.jenkins/terraform-validation-with-security.Jenkinsfile
+++ b/.jenkins/terraform-validation-with-security.Jenkinsfile
@@ -30,7 +30,11 @@ pipeline {
     stage('Terraform Format Check') {
       steps {
         dir('terraform') {
-          sh 'terraform fmt -check -recursive'
+          sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+            terraform fmt -check -recursive
+SCRIPT
+          '''
         }
       }
     }
@@ -38,8 +42,12 @@ pipeline {
     stage('Terraform Validate') {
       steps {
         dir('terraform') {
-          sh 'terraform init -backend=false'
-          sh 'terraform validate'
+          sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+            terraform init -backend=false
+            terraform validate
+SCRIPT
+          '''
         }
       }
     }
@@ -49,12 +57,14 @@ pipeline {
       steps {
         dir('terraform') {
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             # Install tfsec
             curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash || true
             
             # Run security scan (don't fail build on warnings)
             tfsec . --format json --out ../tfsec-results.json || true
             tfsec . || true
+SCRIPT
           '''
         }
       }
@@ -64,6 +74,8 @@ pipeline {
   post {
     always {
       archiveArtifacts artifacts: 'tfsec-results.json', allowEmptyArchive: true
+    }
+    cleanup {
       cleanWs()
     }
     success {
@@ -88,6 +100,9 @@ pipeline {
               export PH_FAILURE_STAGE="terraform-validation-with-security"
               export PH_FAILURE_SUMMARY="Jenkins Terraform validation with security scan failed"
               export PH_RESULT="FAILURE"
+              if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
+                export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+              fi
               bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
                 echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
             '''

--- a/.jenkins/terraform-validation.Jenkinsfile
+++ b/.jenkins/terraform-validation.Jenkinsfile
@@ -71,6 +71,7 @@ EOF
     stage('Setup') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           set -e
           # Ensure we can extract zip without assuming python3 exists.
           if ! command -v python3 >/dev/null 2>&1 && ! command -v unzip >/dev/null 2>&1; then
@@ -123,6 +124,7 @@ EOF
           chmod +x "$TF_BIN_DIR/terraform"
           export PATH="${TF_BIN_DIR}:${PATH}"
           terraform version
+SCRIPT
         '''
       }
     }
@@ -131,6 +133,7 @@ EOF
     stage('Verify Azure Auth') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           set -e
           echo "=== Verifying Azure Workload Identity Configuration ==="
           
@@ -165,6 +168,7 @@ EOF
           echo "✓ Token file size: $(wc -c < $AZURE_FEDERATED_TOKEN_FILE) bytes"
           echo ""
           echo "Workload Identity is configured. Terraform will authenticate using OIDC token."
+SCRIPT
         '''
       }
     }
@@ -173,7 +177,12 @@ EOF
     stage('Terraform Format') {
       steps {
         dir('terraform') {
-          sh 'export PATH="${WORKSPACE}/.bin:${PATH}" && terraform fmt -check -recursive'
+          sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+            export PATH="${WORKSPACE}/.bin:${PATH}"
+            terraform fmt -check -recursive
+SCRIPT
+          '''
         }
       }
     }
@@ -183,6 +192,7 @@ EOF
       steps {
         dir('terraform') {
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             export PATH="${WORKSPACE}/.bin:${PATH}"
             if [ -n "${AZURE_FEDERATED_TOKEN_FILE:-}" ]; then
               export ARM_OIDC_TOKEN_FILE="${AZURE_FEDERATED_TOKEN_FILE}"
@@ -200,6 +210,7 @@ EOF
               -backend-config="subscription_id=${ARM_SUBSCRIPTION_ID}"
             
             terraform validate
+SCRIPT
           '''
         }
       }
@@ -210,11 +221,13 @@ EOF
       steps {
         dir('terraform') {
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             export PATH="${WORKSPACE}/.bin:${PATH}"
             # Use example file for CI validation (contains placeholder values)
             # Real secrets are never stored in blob storage
             echo "INFO: Using example tfvars for validation (placeholder values)"
             cp terraform.tfvars.example terraform.tfvars
+SCRIPT
           '''
         }
       }
@@ -225,6 +238,7 @@ EOF
       steps {
         dir('terraform') {
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             export PATH="${WORKSPACE}/.bin:${PATH}"
             if [ -n "${AZURE_FEDERATED_TOKEN_FILE:-}" ]; then
               export ARM_OIDC_TOKEN_FILE="${AZURE_FEDERATED_TOKEN_FILE}"
@@ -244,6 +258,7 @@ EOF
             else
               echo "No changes detected"
             fi
+SCRIPT
           '''
         }
       }
@@ -257,6 +272,8 @@ EOF
         sh 'export PATH="${WORKSPACE}/.bin:${PATH}" && terraform show -no-color tfplan > tfplan.txt 2>/dev/null || true'
         archiveArtifacts artifacts: 'tfplan.txt', allowEmptyArchive: true
       }
+    }
+    cleanup {
       cleanWs()
     }
     success {
@@ -282,6 +299,9 @@ EOF
                 export PH_FAILURE_STAGE="terraform-validation"
                 export PH_FAILURE_SUMMARY="Jenkins Terraform validation failed"
                 export PH_RESULT="FAILURE"
+                if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
+                  export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+                fi
                 bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
                   echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
               '''

--- a/.jenkins/version-check.Jenkinsfile
+++ b/.jenkins/version-check.Jenkinsfile
@@ -29,6 +29,7 @@ pipeline {
     stage('Install Tools') {
       steps {
         sh '''
+          cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
           set -e
           WORKDIR="${WORKSPACE:-$(pwd)}"
           export WORKDIR
@@ -122,6 +123,7 @@ ENSURE_LABEL_EOF
             fi
           done
           command -v gh >/dev/null 2>&1 && gh --version || echo "gh not installed (ok)"
+SCRIPT
         '''
       }
     }
@@ -134,6 +136,7 @@ ENSURE_LABEL_EOF
           
           // Check Azure Provider version
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             set -e
             WORKDIR="${WORKSPACE:-$(pwd)}"
             export PATH="${WORKDIR}:${PATH}"
@@ -163,6 +166,7 @@ ENSURE_LABEL_EOF
             echo "Latest Azure Provider: ${LATEST_AZURERM}"
             echo "AZURERM_CURRENT=${CURRENT_AZURERM}" >> "$WORKDIR/versions.env"
             echo "AZURERM_LATEST=${LATEST_AZURERM}" >> "$WORKDIR/versions.env"
+SCRIPT
           '''
           
           def azurermCurrent = sh(script: 'WORKDIR="${WORKSPACE:-.}"; grep AZURERM_CURRENT "$WORKDIR/versions.env" | head -1 | cut -d= -f2', returnStdout: true).trim()
@@ -187,6 +191,7 @@ ENSURE_LABEL_EOF
           
           // Check Rocket.Chat image version (prefer Docker Hub tags; fallback to GitHub releases)
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             set -e
             WORKDIR="${WORKSPACE:-$(pwd)}"
             export PATH="${WORKDIR}:${PATH}"
@@ -221,6 +226,7 @@ ENSURE_LABEL_EOF
             echo "RC_CURRENT=${RC_TAG}" >> "$WORKDIR/versions.env"
             echo "RC_LATEST_RELEASE=${LATEST_RC_RELEASE}" >> "$WORKDIR/versions.env"
             echo "RC_LATEST_IMAGE=${LATEST_RC_IMAGE}" >> "$WORKDIR/versions.env"
+SCRIPT
           '''
           
           def rcCurrent = sh(script: 'WORKDIR="${WORKSPACE:-.}"; grep RC_CURRENT "$WORKDIR/versions.env" | cut -d= -f2', returnStdout: true).trim()
@@ -243,8 +249,10 @@ ENSURE_LABEL_EOF
           
           // Check other images from ops/manifests/
           sh '''
+            cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
             # Extract all image tags from manifests
             grep -r "image:" ops/manifests/*.yaml | grep -v "#" | sed 's/.*image: \\(.*\\)/\\1/' | sort -u > image-list.txt
+SCRIPT
           '''
           
           writeJsonFile('image-updates.json', imageUpdates)
@@ -261,6 +269,7 @@ ENSURE_LABEL_EOF
           // Check Helm chart versions for all ArgoCD apps
           def chartLines = sh(
             script: '''
+              cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
               set +e
               export PATH="${WORKSPACE}:${PATH}"
               for app in GrafanaLocal/argocd/applications/*.yaml; do
@@ -283,6 +292,7 @@ ENSURE_LABEL_EOF
                 fi
               done
               true
+SCRIPT
             ''',
             returnStdout: true
           ).trim()
@@ -553,6 +563,7 @@ ENSURE_LABEL_EOF
               writeJsonFile('updates-to-apply.json', updatesToApply)
               
               sh '''
+                cat <<'SCRIPT' | sh .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh "${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
                 set -e
                 WORKDIR="${WORKSPACE:-$(pwd)}"
                 export PATH="${WORKDIR}:${PATH}"
@@ -763,6 +774,7 @@ EOF
                     echo "⚠️ WARNING: Failed to add comment to existing PR #${EXISTING_PR_NUMBER}"
                   fi
                 fi
+SCRIPT
               '''
             } else if (!createdBreakingIssue) {
               echo "✅ All versions are up to date or updates are low risk"
@@ -897,6 +909,9 @@ EOF
               export PH_FAILURE_STAGE="version-check"
               export PH_FAILURE_SUMMARY="Scheduled Jenkins version check failed"
               export PH_RESULT="FAILURE"
+              if [ -f "${WORKSPACE}/.pipelinehealer-log-excerpt.txt" ]; then
+                export PH_LOG_EXCERPT_FILE="${WORKSPACE}/.pipelinehealer-log-excerpt.txt"
+              fi
               bash .jenkins/scripts/send-pipelinehealer-bridge.sh >/dev/null || \
                 echo "⚠️ WARNING: Failed to notify PipelineHealer bridge"
             '''


### PR DESCRIPTION
## Summary
- add a plugin-free shell helper to capture the real failing Jenkins output for PipelineHealer bridge notifications
- update bridge-enabled Jenkinsfiles to keep cleanup in post cleanup blocks and export PH_LOG_EXCERPT_FILE on failure
- document the supported Jenkins bridge capture pattern in the Jenkins docs

## Testing
- bash -n .jenkins/scripts/capture-pipelinehealer-bridge-excerpt.sh
- git diff --check
