### PR TITLE
Adjust Jenkins schedules for AKS uptime window

### DIFF
--- a/.jenkins/README.md
+++ b/.jenkins/README.md
@@ -41,7 +41,7 @@ Automated version checking pipeline:
 - Automatically updates `VERSIONS.md` and code files
 
 **Agent**: `aks-agent` (static AKS agent)
-**Schedule**: Weekdays during the AKS uptime window (`H 14 * * 1-5`, randomized within 14:00-14:59 Europe/London)
+**Schedule**: Weekdays during the AKS uptime window (`H(30-59) 14 * * 1-5`, randomized within 14:30-14:59 Europe/London)
 
 **GitHub output (summary)**:
 - **Breaking updates**: one open issue (updated via comments)
@@ -58,7 +58,7 @@ Automated security validation pipeline:
 - **Issues only** (no PRs): one canonical issue title **"Security: automated scan findings"**; de-dupe by finding that open issue and adding a comment; create the issue only if it doesn’t exist. Bodies built with jq; API failures are not hidden (`if ! curl ...; then echo "⚠️ WARNING: ..."; fi`).
 
 **Agent**: `aks-agent` (static AKS agent)
-**Schedule**: Weekdays during the AKS uptime window (`H 15 * * 1-5`, randomized within 15:00-15:59 Europe/London)
+**Schedule**: Weekdays during the AKS uptime window (`H(0-29) 15 * * 1-5`, randomized within 15:00-15:29 Europe/London)
 
 ## Usage
 

--- a/.jenkins/SECURITY_VALIDATION.md
+++ b/.jenkins/SECURITY_VALIDATION.md
@@ -47,7 +47,7 @@ bash .jenkins/create-security-validation-job.sh
 **Manual Setup:**
 1. **Create Pipeline job** (not multibranch) named `security-validation-{repo-name}` (recommended)
 2. **Use**: `.jenkins/security-validation.Jenkinsfile`
-3. **Schedule**: `H 15 * * 1-5` (weekdays during 15:00-15:59 Europe/London, while the AKS agent is online)
+3. **Schedule**: `H(0-29) 15 * * 1-5` (weekdays during 15:00-15:29 Europe/London, while the AKS agent is online)
 4. **SCM**: Git repository `https://github.com/Canepro/rocketchat-k8s`, branch `main`
 5. **Credentials**: Use `github-token` for GitHub API access
 

--- a/.jenkins/SETUP_AUTOMATED_JOBS.md
+++ b/.jenkins/SETUP_AUTOMATED_JOBS.md
@@ -103,8 +103,8 @@ bash .jenkins/create-security-validation-job.sh Canepro central-observability-hu
   - Scroll to **Build Triggers**
   - Check **Build periodically**
   - **Schedule**:
-    - Version-check: `H 14 * * 1-5` (weekdays during 14:00-14:59 Europe/London, after the 13:30 AKS start)
-    - Security-validation: `H 15 * * 1-5` (weekdays during 15:00-15:59 Europe/London, before the 16:15 AKS stop)
+    - Version-check: `H(30-59) 14 * * 1-5` (weekdays during 14:30-14:59 Europe/London, after the 14:30 AKS start)
+    - Security-validation: `H(0-29) 15 * * 1-5` (weekdays during 15:00-15:29 Europe/London, before the 16:15 AKS stop)
 
 4. **Save** the job
 
@@ -189,10 +189,10 @@ bash .jenkins/test-job-trigger.sh security-validation-rocketchat-k8s
 
 Both jobs use cron syntax for scheduling:
 
-- **version-check**: `H 14 * * 1-5` - Weekdays (Mon-Fri), randomized within 14:00-14:59 Europe/London
-- **security-validation**: `H 15 * * 1-5` - Weekdays (Mon-Fri), randomized within 15:00-15:59 Europe/London
+- **version-check**: `H(30-59) 14 * * 1-5` - Weekdays (Mon-Fri), randomized within 14:30-14:59 Europe/London
+- **security-validation**: `H(0-29) 15 * * 1-5` - Weekdays (Mon-Fri), randomized within 15:00-15:29 Europe/London
 
-**Note**: These schedules are set to run after the cluster auto-starts at 13:30 Europe/London and before it shuts down at 16:15 on weekdays.
+**Note**: These schedules are set to run after the cluster auto-starts at 14:30 Europe/London and before it shuts down at 16:15 on weekdays.
 
 The `H` symbol randomizes the minute to avoid all jobs running at exactly the same time.
 

--- a/.jenkins/WORKFLOWS-AND-STAGES.md
+++ b/.jenkins/WORKFLOWS-AND-STAGES.md
@@ -40,7 +40,7 @@ This document describes the **current** workflows for the version-check job, the
 **Jenkins setup:**
 - **Job type:** Usually a **Pipeline** or **Multibranch** with a single branch (e.g. `main`) and Script Path `.jenkins/version-check.Jenkinsfile`
 - **Script Path:** `.jenkins/version-check.Jenkinsfile`
-- **Schedule:** Weekdays during 14:00-14:59 Europe/London, e.g. `H 14 * * 1-5` (after AKS auto-start at 13:30)
+- **Schedule:** Weekdays during 14:30-14:59 Europe/London, e.g. `H(30-59) 14 * * 1-5` (after AKS auto-start at 14:30)
 - **Config:** `.jenkins/version-check-job-config.xml` uses this script path
 
 **Agent:** `aks-agent`.
@@ -72,7 +72,7 @@ This document describes the **current** workflows for the version-check job, the
 **Jenkins setup:**
 - **Job type:** Pipeline (or multibranch with one branch) with Script Path `.jenkins/security-validation.Jenkinsfile`
 - **Script Path:** `.jenkins/security-validation.Jenkinsfile`
-- **Schedule:** Weekdays during 15:00-15:59 Europe/London, e.g. `H 15 * * 1-5`
+- **Schedule:** Weekdays during 15:00-15:29 Europe/London, e.g. `H(0-29) 15 * * 1-5`
 - **Config:** `.jenkins/security-validation-job-config.xml`
 
 **Agent:** `aks-agent`.

--- a/.jenkins/WORKFLOWS-AND-STAGES.md
+++ b/.jenkins/WORKFLOWS-AND-STAGES.md
@@ -121,8 +121,8 @@ This document describes the **current** workflows for the version-check job, the
 | Job                  | Type              | Script path                          | Trigger        | Agent      |
 |----------------------|-------------------|---------------------------------------|----------------|------------|
 | **Repo (PR/branch)** | Multibranch       | `.jenkins/terraform-validation.Jenkinsfile` | Webhook + scan | `aks-agent` |
-| **Version-check**    | Pipeline/scheduled| `.jenkins/version-check.Jenkinsfile`  | Schedule (e.g. 14:00 Europe/London weekdays) | `aks-agent` |
-| **Security**        | Pipeline/scheduled| `.jenkins/security-validation.Jenkinsfile` | Schedule (e.g. 15:00 Europe/London weekdays) | `aks-agent` |
+| **Version-check**    | Pipeline/scheduled| `.jenkins/version-check.Jenkinsfile`  | Schedule (e.g. 14:30-14:59 Europe/London weekdays) | `aks-agent` |
+| **Security**        | Pipeline/scheduled| `.jenkins/security-validation.Jenkinsfile` | Schedule (e.g. 15:00-15:29 Europe/London weekdays) | `aks-agent` |
 | **Helm only**       | Optional job      | `.jenkins/helm-validation.Jenkinsfile`    | Manual or separate job | `aks-agent` |
 
 ---

--- a/.jenkins/security-validation-job-config.xml
+++ b/.jenkins/security-validation-job-config.xml
@@ -6,13 +6,13 @@ It performs security scanning and creates PRs/issues for remediation.
 -->
 <flow-definition plugin="workflow-job@2.50">
   <actions/>
-  <description>Automated security validation pipeline. Scans infrastructure code for vulnerabilities and creates PRs/issues for remediation. Runs on weekdays during 15:00-15:59 Europe/London before the AKS agent stops.</description>
+  <description>Automated security validation pipeline. Scans infrastructure code for vulnerabilities and creates PRs/issues for remediation. Runs on weekdays during 15:00-15:29 Europe/London before the AKS agent stops.</description>
   <keepDependencies>false</keepDependencies>
   <properties>
     <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
       <triggers>
         <hudson.triggers.TimerTrigger>
-          <spec>H 15 * * 1-5</spec>
+          <spec>H(0-29) 15 * * 1-5</spec>
         </hudson.triggers.TimerTrigger>
       </triggers>
     </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>

--- a/.jenkins/version-check-job-config.xml
+++ b/.jenkins/version-check-job-config.xml
@@ -6,13 +6,13 @@ It checks for version updates and creates PRs/issues automatically.
 -->
 <flow-definition plugin="workflow-job@2.50">
   <actions/>
-  <description>Automated version checking pipeline. Checks for latest versions of all components and creates PRs/issues for updates. Runs on weekdays during 14:00-14:59 Europe/London after the AKS agent starts.</description>
+  <description>Automated version checking pipeline. Checks for latest versions of all components and creates PRs/issues for updates. Runs on weekdays during 14:30-14:59 Europe/London after the AKS agent starts.</description>
   <keepDependencies>false</keepDependencies>
   <properties>
     <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
       <triggers>
         <hudson.triggers.TimerTrigger>
-          <spec>H 14 * * 1-5</spec>
+          <spec>H(30-59) 14 * * 1-5</spec>
         </hudson.triggers.TimerTrigger>
       </triggers>
     </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>

--- a/DIAGRAM.md
+++ b/DIAGRAM.md
@@ -149,7 +149,7 @@ RocketChat → OTel Collector → Tempo → Grafana Trace UI
 Two CronJobs ensure cluster health:
 
 1. **Stale Pod Cleanup** (`aks-stale-pod-cleanup`)
-   - **Schedule**: Weekdays at 14:00 Europe/London (`0 14 * * 1-5`, 30 min after cluster auto-start)
+   - **Schedule**: Weekdays at 15:00 Europe/London (`0 15 * * 1-5`, 30 min after cluster auto-start)
    - **Purpose**: Remove Succeeded/Failed/Unknown pods after cluster restarts
    - **Dashboard**: "AKS Maintenance Jobs" in Grafana
 

--- a/MIGRATION_STATUS.md
+++ b/MIGRATION_STATUS.md
@@ -18,7 +18,7 @@ This file tracks **where we are vs** the original migration plan (`.cursor/plans
 - **Migration Status**: ✅ **COMPLETE** - Merged to `main` branch, all ArgoCD apps tracking `main`
 - **AKS cluster**: running (auto-start/stop configured: 13:30-16:15 Europe/London on weekdays, stays off weekends), Terraform plan clean after azurerm v4 apply.
 - **Jenkins CI**: Terraform plan parity clean (no changes detected) after azurerm v4 apply (2026-02-04).
-- **Cost Optimization**: Short work-window schedule reduces monthly runtime to ~55 hours/month on the personal PAYG subscription.
+- **Cost Optimization**: Short work-window schedule reduces monthly runtime to ~39 hours/month on the personal PAYG subscription.
 - **ArgoCD apps (AKS)** - All tracking `main` branch:
   - `aks-rocketchat-ops`: syncing / infrastructure + observability.
   - `aks-rocketchat-helm`: Rocket.Chat Helm deploy.
@@ -112,7 +112,7 @@ This file tracks **where we are vs** the original migration plan (`.cursor/plans
 ## Completed Tasks (2026-01-20)
 
 - [x] **Automated maintenance jobs deployed** (2026-01-20):
-  - `aks-stale-pod-cleanup` CronJob: Weekday cleanup of orphaned pods after cluster restart (`0 14 * * 1-5`, 14:00 Europe/London)
+  - `aks-stale-pod-cleanup` CronJob: Weekday cleanup of orphaned pods after cluster restart (`0 15 * * 1-5`, 15:00 Europe/London)
   - Grafana monitoring dashboard imported (`grafana-dashboard-maintenance-jobs.json`)
   - Alert rules created (`grafana-alerts-maintenance-jobs.yaml`)
   - Documentation: `ops/MAINTENANCE_MONITORING.md`

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -91,7 +91,7 @@ The AKS cluster uses **Azure Automation** to automatically start and stop on a s
 - **Start Time**: 13:30 Europe/London on weekdays
 - **Stop Time**: 16:15 Europe/London on weekdays
 - **Weekends**: Cluster stays off
-- **Runtime**: ~2.75 hours/day × 5 weekdays = ~13.75 hours/week = ~55 hours/month
+- **Runtime**: ~1.75 hours/day × 5 weekdays = ~8.75 hours/week = ~39 hours/month
 - **Goal**: keep the personal PAYG cluster available only during the active work window
 
 ## 🔔 CI notifications (avoid daily Jenkins logins)
@@ -609,7 +609,7 @@ kubectl -n monitoring logs job/manual-prune-<timestamp>
 ```
 
 ### Stale Pod Cleanup (Daily after Cluster Restart)
-The `aks-stale-pod-cleanup` CronJob runs on weekdays at 14:00 Europe/London (`0 14 * * 1-5` with `timeZone: Europe/London`), 30 minutes after cluster auto-start, to remove orphaned pods left in terminal states after AKS cluster shutdown/restart cycles.
+The `aks-stale-pod-cleanup` CronJob runs on weekdays at 15:00 Europe/London (`0 15 * * 1-5` with `timeZone: Europe/London`), 30 minutes after cluster auto-start, to remove orphaned pods left in terminal states after AKS cluster shutdown/restart cycles.
 
 **What it cleans:**
 - `Succeeded` pods (Completed jobs from before shutdown)

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ spec:
 The cluster runs on an automated schedule to minimize costs:
 
 - **Runtime**: Weekdays 14:30-16:15 Europe/London (~1.75 hours/day)
-- **Monthly Hours**: ~55 hours
+- **Monthly Hours**: ~39 hours
 - **Reasoning**: enough startup buffer for Argo resync plus a short working window on a personal PAYG budget
 
 Schedule resources live in `terraform/automation.tf`, and operators change the actual start/stop times through `terraform.tfvars` as documented in [`terraform/README.md`](terraform/README.md).
@@ -253,7 +253,7 @@ Schedule resources live in `terraform/automation.tf`, and operators change the a
 | Job | Schedule | Purpose |
 |-----|----------|---------|
 | `k3s-image-prune` | Sunday 03:00 UTC | Remove unused container images |
-| `aks-stale-pod-cleanup` | Weekdays at 14:00 Europe/London (`0 14 * * 1-5`) | Clean up pods after cluster restart |
+| `aks-stale-pod-cleanup` | Weekdays at 15:00 Europe/London (`0 15 * * 1-5`) | Clean up pods after cluster restart |
 
 ## CI/CD Pipeline
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ spec:
 
 The cluster runs on an automated schedule to minimize costs:
 
-- **Runtime**: Weekdays 13:30-16:15 Europe/London (~2.75 hours/day)
+- **Runtime**: Weekdays 14:30-16:15 Europe/London (~1.75 hours/day)
 - **Monthly Hours**: ~55 hours
 - **Reasoning**: enough startup buffer for Argo resync plus a short working window on a personal PAYG budget
 

--- a/jenkins-values.yaml
+++ b/jenkins-values.yaml
@@ -90,9 +90,9 @@ controller:
         jobs:
           - script: |
               pipelineJob('version-check-rocketchat-k8s') {
-                description('Automated version checking pipeline for rocketchat-k8s. Runs on weekdays during 14:00-14:59 Europe/London and stays aligned with the repo Jenkinsfile.')
+                description('Automated version checking pipeline for rocketchat-k8s. Runs on weekdays during 14:30-14:59 Europe/London and stays aligned with the repo Jenkinsfile.')
                 triggers {
-                  cron('H 14 * * 1-5')
+                  cron('H(30-59) 14 * * 1-5')
                 }
                 definition {
                   cpsScm {
@@ -114,9 +114,9 @@ controller:
                 }
               }
               pipelineJob('security-validation-rocketchat-k8s') {
-                description('Automated security validation pipeline for rocketchat-k8s. Runs on weekdays during 15:00-15:59 Europe/London and stays aligned with the repo Jenkinsfile.')
+                description('Automated security validation pipeline for rocketchat-k8s. Runs on weekdays during 15:00-15:29 Europe/London and stays aligned with the repo Jenkinsfile.')
                 triggers {
-                  cron('H 15 * * 1-5')
+                  cron('H(0-29) 15 * * 1-5')
                 }
                 definition {
                   cpsScm {

--- a/ops/MAINTENANCE_MONITORING.md
+++ b/ops/MAINTENANCE_MONITORING.md
@@ -30,7 +30,7 @@ Import alert rules from: `ops/manifests/grafana-alerts-maintenance-jobs.yaml`
 ## 📊 What Gets Monitored
 
 ### CronJob: `aks-stale-pod-cleanup`
-- **Schedule:** Weekdays at 14:00 Europe/London (30 minutes after cluster start)
+- **Schedule:** Weekdays at 15:00 Europe/London (30 minutes after cluster start)
 - **Purpose:** Clean up orphaned pods after cluster restart
 - **Expected duration:** 10-30 seconds
 - **Target phases:** Succeeded, Failed, Unknown

--- a/ops/manifests/grafana-alerts-maintenance-jobs.yaml
+++ b/ops/manifests/grafana-alerts-maintenance-jobs.yaml
@@ -34,7 +34,7 @@ groups:
             This may indicate the CronJob is suspended or there's a scheduling issue.
             
             Current time since last run: {{ $value | humanizeDuration }}
-            Expected schedule: Weekdays at 14:00 Europe/London
+            Expected schedule: Weekdays at 15:00 Europe/London
             
             Actions:
             1. Check CronJob status: kubectl get cronjob aks-stale-pod-cleanup -n monitoring

--- a/ops/manifests/maintenance-stale-pod-cleanup.yaml
+++ b/ops/manifests/maintenance-stale-pod-cleanup.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations:
     canepro.me/description: "Cleans up Completed/Failed/Unknown pods left after cluster restarts"
 spec:
-  schedule: "0 14 * * 1-5"  # Weekdays at 14:00 Europe/London (30 min after cluster startup)
+  schedule: "0 15 * * 1-5"  # Weekdays at 15:00 Europe/London (30 min after cluster startup)
   timeZone: "Europe/London"
   concurrencyPolicy: Forbid  # Don't run multiple instances simultaneously
   startingDeadlineSeconds: 600  # Avoid running if the cluster was down for too long


### PR DESCRIPTION
## Summary
- move  to a hashed minute within 14:30-14:59 Europe/London so it cannot fire before the 14:30 cluster start
- narrow  to a hashed minute within 15:00-15:29 Europe/London so it has more runway before the 16:15 shutdown
- update fallback Jenkins XML and schedule docs to match the live job behavior

## Notes
- I already applied the same schedule change directly to the live Jenkins jobs to avoid another missed window before this PR merges.
- Earlier today I also corrected the live branch pin for both jobs from  to ; this PR is only about the schedule window.

## Verification
- verified the live Jenkins job XML now shows:
  - : 
  - : 
- repo config and fallback XML match the same values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Jenkins job scheduling windows for version-check and security-validation operations.
  * Version-check jobs now run 14:30–14:59 Europe/London (previously 14:00–14:59).
  * Security-validation jobs now run 15:00–15:29 Europe/London (previously 15:00–15:59).
  * Automated cluster runtime window adjusted to 14:30–16:15 Europe/London, reducing daily runtime from ~2.75 to ~1.75 hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->