### PR TITLE
Clarify PAYG budget source and stopped-cluster residual cost

### DIFF
--- a/MIGRATION_STATUS.md
+++ b/MIGRATION_STATUS.md
@@ -20,6 +20,8 @@ This file tracks **where we are vs** the original migration plan (`.cursor/plans
 - **AKS shape**: Kubernetes `1.34.3`, node pool `system2`, 2 nodes, `Standard_B4ms`, max pods 110, 128GB OS disk.
 - **Jenkins CI**: Terraform plan parity clean (no changes detected) after azurerm v4 apply (2026-02-04).
 - **Cost Optimization**: Manual start plus scheduled safety-stop avoids daily compute spend for a rarely used test cluster.
+- **Budget source of truth**: `terraform/budget.tf` now manages the personal PAYG budget `aks-canepro-monthly-budget`. Legacy alert mail for budget name `AKS_Budget` points at the pre-migration subscription context and should be cleaned up there.
+- **Residual stopped-cluster spend**: Stopping AKS does not remove all cost. Standard Load Balancer, public IPs, and persistent disks in the managed resource group still bill until they are deleted or redesigned.
 - **ArgoCD apps (AKS)** - All tracking `main` branch:
   - `aks-rocketchat-ops`: syncing / infrastructure + observability.
   - `aks-rocketchat-helm`: Rocket.Chat Helm deploy.

--- a/MIGRATION_STATUS.md
+++ b/MIGRATION_STATUS.md
@@ -142,7 +142,7 @@ This file tracks **where we are vs** the original migration plan (`.cursor/plans
   - 3 secrets created in Azure Key Vault (admin username/password, GitHub token)
   - Deployment guide created (`JENKINS_DEPLOYMENT.md`)
   - DNS A record configured (`jenkins.canepro.me`)
-  - **Status**: Historical pre-cutover note; Jenkins was staged before the old 16:00 Europe/London weekday startup window and is now superseded by the current 13:30 Europe/London schedule.
+  - **Status**: Historical pre-cutover note; Jenkins was staged before the old weekday auto-start windows and is now superseded by the current manual-start-default posture with a 16:15 Europe/London safety-stop.
 
 ## Completed Upgrades (2026-01-16)
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,10 @@ The cluster runs on an automated schedule to minimize costs:
 - **Monthly Hours**: ~39 hours
 - **Reasoning**: enough startup buffer for Argo resync plus a short working window on a personal PAYG budget
 
+The current budget source of truth is the Terraform-managed personal PAYG subscription budget in [`terraform/budget.tf`](terraform/budget.tf). If Azure sends an alert for budget name `AKS_Budget`, treat it as legacy pre-migration noise until the old subscription-side budget or action group is removed. The current PAYG budget name is `aks-canepro-monthly-budget`.
+
+Stopping AKS removes compute spend, but it does not remove all spend. Standard Load Balancer, public IPs, and persistent disks in the managed resource group can still accrue charges while the cluster is stopped.
+
 Schedule resources live in `terraform/automation.tf`, and operators change the actual start/stop times through `terraform.tfvars` as documented in [`terraform/README.md`](terraform/README.md).
 
 ### Maintenance Jobs

--- a/README.md
+++ b/README.md
@@ -240,11 +240,12 @@ spec:
 
 ### Cost Optimization
 
-The cluster runs on an automated schedule to minimize costs:
+The default cost posture is manual start plus a weekday safety-stop:
 
-- **Runtime**: Weekdays 14:30-16:15 Europe/London (~1.75 hours/day)
-- **Monthly Hours**: ~39 hours
-- **Reasoning**: enough startup buffer for Argo resync plus a short working window on a personal PAYG budget
+- **Start**: Manual by default
+- **Stop**: 16:15 Europe/London on weekdays
+- **Auto-start**: Disabled by default
+- **Reasoning**: enough control for occasional Rocket.Chat work/testing without paying for a standing weekday start window
 
 The current budget source of truth is the Terraform-managed personal PAYG subscription budget in [`terraform/budget.tf`](terraform/budget.tf). If Azure sends an alert for budget name `AKS_Budget`, treat it as legacy pre-migration noise until the old subscription-side budget or action group is removed. The current PAYG budget name is `aks-canepro-monthly-budget`.
 

--- a/runbooks/weekly-aks-maintenance.md
+++ b/runbooks/weekly-aks-maintenance.md
@@ -73,6 +73,7 @@ The Codex automation should do the following:
    - Apply safe updates through repo-backed GitOps changes when evidence and checks support them and Azure or OKE will reconcile from Git. Draft risky runtime or hard-gated updates instead of applying them directly.
    - Run Terraform apply only after fmt, validate, and plan evidence is clean and the expected diff is documented in the report.
    - Use Argo CD refresh or sync when reconciliation is stale or required after a Git-backed change, then capture before/after health and sync status.
+   - When AKS is stopped, still review managed resource group residual cost. Standard Load Balancer, public IPs, and disks can keep billing even with node compute off.
 6. Draft a dark-first HTML report using the `codex-html-report` skill. Include:
    - Cluster power-state decision and whether AKS was started.
    - Kubernetes health summary.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -276,7 +276,7 @@ az aks start --resource-group rg-canepro-aks --name aks-canepro
 az aks stop --resource-group rg-canepro-aks --name aks-canepro
 ```
 
-**Note:** Schedules use `lifecycle { ignore_changes = [start_time] }` to prevent Terraform from updating schedule times on every run. To update schedules, temporarily remove `ignore_changes`, update variables, apply, then restore `ignore_changes`.
+**Note:** Schedule start times are stabilized through `time_static.automation_schedule_anchor` plus the `automation_schedule_seed.pl` external helper in `terraform/automation.tf`. Update the schedule variables, review the resulting plan, and apply the intended change instead of looking for a `lifecycle ignore_changes` block on the schedule resources.
 
 ### Historical schedule comparison
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -236,7 +236,7 @@ terraform init -reconfigure -backend-config=backend.hcl -migrate-state
 
 The AKS cluster uses **Azure Automation** to keep the test environment off by default without destroying it. Start the cluster manually when Rocket.Chat testing is needed; the scheduled stop remains as a safety net if the cluster is left running.
 
-### Current Recommended Schedule (2026-05-20)
+### Current Recommended Posture (2026-05-20)
 
 - **Start Time**: Manual only by default (`enable_auto_start = false`)
 - **Stop Time**: 16:15 (4:15 PM) on weekdays
@@ -278,12 +278,12 @@ az aks stop --resource-group rg-canepro-aks --name aks-canepro
 
 **Note:** Schedules use `lifecycle { ignore_changes = [start_time] }` to prevent Terraform from updating schedule times on every run. To update schedules, temporarily remove `ignore_changes`, update variables, apply, then restore `ignore_changes`.
 
-### Cost Savings
+### Historical schedule comparison
 
 - **Previous schedule** (08:30-23:00): ~72.5 hours/week = ~290 hours/month
 - **Later evening schedule** (16:00-23:00): ~35 hours/week = ~140 hours/month
-- **Current recommended schedule** (13:30-16:15): ~13.75 hours/week = ~55 hours/month
-- **Savings vs 16:00-23:00**: ~61% reduction in runtime hours
+- **Temporary auto-start window** (13:30-16:15): ~13.75 hours/week = ~55 hours/month
+- **Current default**: manual start only, with a 16:15 weekday safety-stop
 
 ## Jenkins + Terraform (CI Validation)
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -243,6 +243,8 @@ The AKS cluster uses **Azure Automation** to keep the test environment off by de
 - **Weekends**: No scheduled start; cluster stays off unless manually started
 - **Runtime**: Pay-per-use; bounded by manual starts plus the weekday safety-stop
 - **Reasoning**: This cluster is used mainly for occasional Rocket.Chat work/testing, so daily auto-start is wasteful on a personal PAYG subscription.
+- **Budget source of truth**: `budget.tf` creates the current subscription budget `aks-canepro-monthly-budget`. If an email alert still references `AKS_Budget`, that alert is from the pre-migration subscription-side budget or action group and should be removed there instead of changing the PAYG Terraform budget.
+- **Residual spend while stopped**: `az aks stop` removes node compute, but Standard Load Balancer, public IPs, and persistent disks in the managed resource group still incur charges.
 
 ### Configuration
 


### PR DESCRIPTION
## Summary
- document the current Terraform-managed PAYG budget name as `aks-canepro-monthly-budget`
- clarify that alerts mentioning `AKS_Budget` are legacy pre-migration budget or action-group noise, not the current source of truth
- document the residual Azure spend that remains after `az aks stop`, including load balancer, public IP, and disk costs
- align the cost-posture docs on the current default: manual start, 16:15 weekday safety-stop, no scheduled auto-start
- add the residual-cost reminder to the weekly AKS maintenance runbook

## Validation
- confirmed the current budget definition in `terraform/budget.tf`
- checked the branch diff against `main`
- ran `git diff --check`
- confirmed the branch is pushed and isolated from the existing untracked report artifact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated cost-optimization guidance to reflect the current AKS operating posture: manual start by default, weekday safety-stop at 16:15 Europe/London, and no weekend scheduling.
  * Clarified the current budget source of truth and noted legacy budget alert cleanup.
  * Added guidance that stopping AKS reduces compute costs but may still leave charges for load balancers, public IPs, and disks.
  * Refreshed maintenance notes and historical schedule references to match the current setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->