### PR TITLE
chore: patch Rocket.Chat to 8.2.6

### DIFF
--- a/GrafanaLocal/argocd/applications/aks-rocketchat-helm.yaml
+++ b/GrafanaLocal/argocd/applications/aks-rocketchat-helm.yaml
@@ -1,7 +1,7 @@
 # ArgoCD Application: Rocket.Chat Helm Deployment
 # This ArgoCD Application deploys Rocket.Chat using the official Helm chart.
 # The chart is sourced from Rocket.Chat's Helm repository, and values come from Git (values.yaml).
-# See VERSIONS.md for version tracking. Current: Rocket.Chat chart 6.29.0, app 8.2.0
+# See VERSIONS.md for version tracking. Current: Rocket.Chat chart 6.29.0, app 8.2.6
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,7 +2,7 @@
 
 This document tracks all software versions used in the AKS Rocket.Chat deployment. Update this file when upgrading any component.
 
-**Last Updated**: 2026-03-26
+**Last Updated**: 2026-06-18
 
 ## Upgrade Status Legend
 
@@ -28,7 +28,7 @@ This document tracks all software versions used in the AKS Rocket.Chat deploymen
 - Prometheus NATS Exporter 0.9.1 → 0.10.0 - Minor version, lower risk
 
 **Production critical - check before upgrading**:
-- Rocket.Chat 8.2.0 - Application version, test thoroughly
+- Rocket.Chat 8.2.6 - Current 8.2 patch-line security release
 - Traefik chart 34.4.1 - Ingress controller, test carefully
 - MongoDB Operator 1.6.1 - Database operator, test carefully
 
@@ -79,7 +79,7 @@ This document tracks all software versions used in the AKS Rocket.Chat deploymen
 
 | Component | Current Version | Latest Version | Upgrade Status | Location | Update Source |
 |-----------|----------------|----------------|----------------|----------|---------------|
-| **Rocket.Chat Application** | `8.2.0` | `8.2.0` | ✅ **Up to date** (2026-03-26) | `values.yaml` | [Rocket.Chat Releases](https://github.com/RocketChat/Rocket.Chat/releases) |
+| **Rocket.Chat Application** | `8.2.6` | `8.2.6` | ✅ **Security patched** (2026-06-18) | `values.yaml` | [Rocket.Chat Releases](https://github.com/RocketChat/Rocket.Chat/releases) |
 | **Rocket.Chat Helm Chart** | `6.29.0` | `Check latest` | ⚠️ **Check latest** (test chart upgrades carefully) | `GrafanaLocal/argocd/applications/aks-rocketchat-helm.yaml` | [Rocket.Chat Helm Charts](https://github.com/RocketChat/charts) |
 | **Traefik Helm Chart** | `34.4.1` | `Check latest` | ⚠️ **Check latest** (ingress controller, test carefully) | `GrafanaLocal/argocd/applications/aks-traefik.yaml` | [Traefik Helm Chart](https://github.com/traefik/traefik-helm-chart) |
 | **MongoDB Operator Helm Chart** | `1.6.1` | `Check latest` | ⚠️ **Check latest** (database operator, test carefully) | `GrafanaLocal/argocd/applications/aks-rocketchat-mongodb-operator.yaml` | [MongoDB Operator](https://github.com/mongodb/mongodb-kubernetes-operator) |
@@ -184,5 +184,6 @@ kubectl logs -n monitoring -l app=prometheus-agent --tail=50
 - **OTel Collector** `v0.142.0` (upgraded from v0.88.0) - check compatibility with your observability hub
 - **Promtail** `v3.6.0` (upgraded from v2.9.3) - should be compatible with your Loki version at `observability.canepro.me`
 - **NATS Server** `2.4-alpine` (can upgrade to 2.10.24) - major version jump, test carefully
+- **Rocket.Chat** `8.2.6` keeps the deployment on the existing 8.2 patch line while applying the June 2026 security hotfix release.
 - **Terraform** `>= 1.8` - latest stable recommended for Azure provider compatibility
 - **Azure Provider** `~> 4.77.0` - review the v4 migration guide ([AzureRM v4 upgrade guide](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide)) and validate in Cloud Shell

--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,7 @@
 # These values override the default Rocket.Chat Helm chart values.
 # Chart: rocketchat/rocketchat 6.29.0 - See VERSIONS.md for latest version and upgrade status.
 # Goal: match current runtime behavior while moving to Helm+values GitOps.
-# See VERSIONS.md for version tracking. Current: Rocket.Chat chart 6.29.0, app 8.2.0
+# See VERSIONS.md for version tracking. Current: Rocket.Chat chart 6.29.0, app 8.2.6
 # Test PR: This is a test change to verify Jenkins PR validation workflow
 
 # Rocket.Chat container image configuration
@@ -11,7 +11,7 @@ image:
   repository: registry.rocket.chat/rocketchat/rocket.chat  # Official Rocket.Chat image registry
   # Pin to the currently running version for the migration. Upgrade later by changing ONLY this value.
   # See VERSIONS.md for latest version and upgrade status
-  tag: "8.2.0"  # Rocket.Chat application version - Check latest at https://github.com/RocketChat/Rocket.Chat/releases
+  tag: "8.2.6"  # Rocket.Chat 8.2 patch-line security release - Check latest at https://github.com/RocketChat/Rocket.Chat/releases
   # Use Always so nodes pick up upstream rebuilds of the same tag (common for base-image CVE fixes).
   # If you want fully immutable deploys, switch to digest pinning (if supported by the chart) and revert to IfNotPresent.
   pullPolicy: Always  # Image pull policy (always pull to avoid running a stale cached image)

--- a/vex/rocketchat-vex.json
+++ b/vex/rocketchat-vex.json
@@ -2,19 +2,64 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://github.com/Canepro/rocketchat-k8s/blob/main/vex/rocketchat-vex.json",
   "author": "Canepro",
-  "timestamp": "2026-03-26T16:00:00Z",
-  "version": 1,
+  "timestamp": "2026-06-18T10:45:00Z",
+  "version": 2,
   "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-55666"
+      },
+      "products": [
+        {
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6?repository_url=registry.rocket.chat"
+        },
+        {
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6"
+        }
+      ],
+      "status": "fixed",
+      "impact_statement": "Rocket.Chat 8.2.6 is the patched 8.2 release for GHSA-wx3c-76rf-wpwf / CVE-2026-55666."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-48929"
+      },
+      "products": [
+        {
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6?repository_url=registry.rocket.chat"
+        },
+        {
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6"
+        }
+      ],
+      "status": "fixed",
+      "impact_statement": "Rocket.Chat 8.2.6 is the patched 8.2 release for unauthenticated file deletion."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-55762"
+      },
+      "products": [
+        {
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6?repository_url=registry.rocket.chat"
+        },
+        {
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6"
+        }
+      ],
+      "status": "fixed",
+      "impact_statement": "Rocket.Chat 8.2.6 is the patched 8.2 release for GHSA-8hhc-j325-rxqp / CVE-2026-55762."
+    },
     {
       "vulnerability": {
         "name": "CVE-2025-15467"
       },
       "products": [
         {
-          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.0?repository_url=registry.rocket.chat"
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6?repository_url=registry.rocket.chat"
         },
         {
-          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.0"
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6"
         }
       ],
       "status": "not_affected",
@@ -27,10 +72,10 @@
       },
       "products": [
         {
-          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.0?repository_url=registry.rocket.chat"
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6?repository_url=registry.rocket.chat"
         },
         {
-          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.0"
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6"
         }
       ],
       "status": "not_affected",
@@ -43,10 +88,10 @@
       },
       "products": [
         {
-          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.0?repository_url=registry.rocket.chat"
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6?repository_url=registry.rocket.chat"
         },
         {
-          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.0"
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6"
         }
       ],
       "status": "not_affected",
@@ -59,10 +104,10 @@
       },
       "products": [
         {
-          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.0?repository_url=registry.rocket.chat"
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6?repository_url=registry.rocket.chat"
         },
         {
-          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.0"
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6"
         }
       ],
       "status": "not_affected",
@@ -75,10 +120,10 @@
       },
       "products": [
         {
-          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.0?repository_url=registry.rocket.chat"
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6?repository_url=registry.rocket.chat"
         },
         {
-          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.0"
+          "@id": "pkg:docker/rocketchat/rocket.chat@8.2.6"
         }
       ],
       "status": "not_affected",


### PR DESCRIPTION
This pull request updates the Rocket.Chat deployment to use the latest 8.2.6 security patch release, ensuring that recent vulnerabilities are addressed. The version references in deployment manifests, configuration files, and documentation are updated accordingly. The VEX (Vulnerability Exploitability eXchange) document is also revised to reflect the fixed vulnerabilities in this release.

**Rocket.Chat upgrade and security patching:**

* Upgraded Rocket.Chat application version from 8.2.0 to 8.2.6 in `values.yaml`, `GrafanaLocal/argocd/applications/aks-rocketchat-helm.yaml`, and all related documentation to ensure the deployment uses the latest 8.2 patch-line security release. [[1]](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eL6-R14) [[2]](diffhunk://#diff-5cfa99b566a856d6cf886c942ddcec7cc50cce78a2ee5d0a8ffab299ca988c0dL4-R4) [[3]](diffhunk://#diff-ef823b96251cbdeadda227eec197b2592139225ce594339e1ec1d6a7e6412dbeL31-R31) [[4]](diffhunk://#diff-ef823b96251cbdeadda227eec197b2592139225ce594339e1ec1d6a7e6412dbeL82-R82)
* Updated the VEX document (`vex/rocketchat-vex.json`) to version 2, adding statements that Rocket.Chat 8.2.6 fixes CVE-2026-55666, CVE-2026-48929, and CVE-2026-55762, and updating all product references from 8.2.0 to 8.2.6. [[1]](diffhunk://#diff-ef111faa677957d508cbf6315de4a4243e09bb74ff5c51f88ca2c2a12f2a9e90L5-R62) [[2]](diffhunk://#diff-ef111faa677957d508cbf6315de4a4243e09bb74ff5c51f88ca2c2a12f2a9e90L30-R78) [[3]](diffhunk://#diff-ef111faa677957d508cbf6315de4a4243e09bb74ff5c51f88ca2c2a12f2a9e90L46-R94) [[4]](diffhunk://#diff-ef111faa677957d508cbf6315de4a4243e09bb74ff5c51f88ca2c2a12f2a9e90L62-R110) [[5]](diffhunk://#diff-ef111faa677957d508cbf6315de4a4243e09bb74ff5c51f88ca2c2a12f2a9e90L78-R126)

**Documentation and tracking updates:**

* Updated `VERSIONS.md` to reflect the new Rocket.Chat version, latest patch status, and last updated date. Also clarified that 8.2.6 is a security hotfix release. [[1]](diffhunk://#diff-ef823b96251cbdeadda227eec197b2592139225ce594339e1ec1d6a7e6412dbeL5-R5) [[2]](diffhunk://#diff-ef823b96251cbdeadda227eec197b2592139225ce594339e1ec1d6a7e6412dbeL31-R31) [[3]](diffhunk://#diff-ef823b96251cbdeadda227eec197b2592139225ce594339e1ec1d6a7e6412dbeL82-R82) [[4]](diffhunk://#diff-ef823b96251cbdeadda227eec197b2592139225ce594339e1ec1d6a7e6412dbeR187)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Upgraded Rocket.Chat to version 8.2.6 with June 2026 security hotfix addressing critical vulnerabilities

* **Documentation**
  * Updated version tracking, compatibility notes, and deployment documentation to reflect the latest release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->