### PR TITLE
Document AKS-hosted Jenkins agent CI timing

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -103,12 +103,14 @@ This repo is set up so “routine automation” reports into GitHub:
 
 Operational expectation:
 - If the AKS cluster is **stopped**, AKS-side scheduled jobs won’t run until the cluster is manually started.
+- PR checks that target the AKS-hosted `aks-agent` can sit **Pending** while AKS is stopped. During weekly maintenance, start AKS through the runner, verify `jenkins-static-agent` is Ready, then refresh the PR check before deciding whether a PR is mergeable or blocked.
 - Leave the issue/PR open if you’re not ready; the jobs will append comments/updates rather than spamming duplicates.
 
 ### Jenkins Split-Agent (Controller on OKE, Agent on AKS)
 
 When Jenkins runs in split-agent mode (controller on OKE, static agent on AKS):
 
+- **PR check interpretation:** The OKE controller can be healthy while PR checks are still waiting for AKS capacity. A pending `aks-agent` check during an off cluster window means "agent offline" until proven otherwise; it becomes a blocker only after AKS is running, the static agent is healthy, and Jenkins still cannot schedule or complete the build.
 - **Phase 4 – Automated graceful disconnect:** The Azure Automation **stop runbook** (`Stop-AKS-Cluster`) can disable the Jenkins `aks-agent` node before stopping AKS. Set `jenkins_graceful_disconnect_url` and `jenkins_graceful_disconnect_user` in `terraform.tfvars` (e.g. `https://jenkins.canepro.me` and `admin`; production URL now that domain cutover is complete), then create an Automation Variable **`JenkinsAksAgentDisconnectToken`** in the same Automation Account (see below). The runbook will call the Jenkins API to disable the node, wait 60 seconds, then stop AKS. No token in Terraform/tfvars.
 - **Manual procedure:** If not using Phase 4, follow the **hub-docs** runbook (`JENKINS-SPLIT-AGENT-RUNBOOK.md`): before stopping AKS, check for running builds on `aks-agent`, put the node offline (UI, API, or CLI), wait 30–60 seconds, then run the AKS stop. On startup, the agent reconnects; bring the node back online in Jenkins if it was left offline.
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -103,7 +103,7 @@ This repo is set up so “routine automation” reports into GitHub:
 
 Operational expectation:
 - If the AKS cluster is **stopped**, AKS-side scheduled jobs won’t run until the cluster is manually started.
-- PR checks that target the AKS-hosted `aks-agent` can sit **Pending** while AKS is stopped. During weekly maintenance, start AKS through the runner, verify `jenkins-static-agent` is Ready, then refresh the PR check before deciding whether a PR is mergeable or blocked.
+- PR checks that target the AKS-hosted `aks-agent` can sit **Pending** while AKS is stopped. During weekly maintenance, start AKS through the runner, verify `jenkins-static-agent` is Ready, then refresh the PR check before deciding whether a PR is mergeable or blocked. If AKS is stopped but the runner skips start because this week's activity log already has start/stop activity, rerun with `--execute --force-start-when-stopped --shutdown-mode leave-auto` for a deliberate PR CI unblock window.
 - Leave the issue/PR open if you’re not ready; the jobs will append comments/updates rather than spamming duplicates.
 
 ### Jenkins Split-Agent (Controller on OKE, Agent on AKS)
@@ -169,7 +169,7 @@ The weekly maintenance automation uses the repo runner plus Codex/Grafana MCP ch
 python3 scripts/weekly_aks_maintenance.py --execute --shutdown-mode leave-auto
 ```
 
-The runner only starts or stops AKS when `--execute` is passed. It writes local evidence under `reports/weekly-aks-maintenance/`, which is ignored by Git. Codex turns that evidence, Grafana MCP checks, and the GitHub issue/PR queue into a dark-first HTML report, then sends Selene the completed run update and writes a searchable second-brain activity note.
+The runner only starts or stops AKS when `--execute` is passed. By default it will not start a stopped cluster again if Azure activity logs already show AKS start/stop activity this week; use `--force-start-when-stopped` only for an intentional PR CI unblock window after confirming the cost window is acceptable. It writes local evidence under `reports/weekly-aks-maintenance/`, which is ignored by Git. Codex turns that evidence, Grafana MCP checks, and the GitHub issue/PR queue into a dark-first HTML report, then sends Selene the completed run update and writes a searchable second-brain activity note.
 
 See `runbooks/weekly-aks-maintenance.md` for the stop conditions. In short: public GitHub issue/PR updates, repo-backed GitOps changes, checked Terraform applies, and Argo CD refresh/sync actions are allowed on Vincent's personal repos when evidence supports them and Azure or OKE reconciles the expected change. Secret-value handling, out-of-band live mutation, unchecked or destructive Terraform plans, Azure cost actions outside the checked plan, ingress changes, RBAC changes, direct Helm upgrades, Argo CD prune/force/delete/rollback actions, and auto-shutdown changes still need explicit approval.
 

--- a/runbooks/weekly-aks-maintenance.md
+++ b/runbooks/weekly-aks-maintenance.md
@@ -43,6 +43,7 @@ Generated weekly evidence is intentionally ignored by Git. Promote only curated 
 - Default shutdown mode is `leave-auto`, because Jenkins jobs may still run inside the existing weekday window.
 - Use `--shutdown-mode stop-if-started` only when the weekly run should stop AKS immediately after checks.
 - The runner uses a temporary kubeconfig. It does not overwrite the operator kubeconfig.
+- Jenkins PR checks that require `aks-agent` may remain `Pending` while AKS is stopped. Treat that as expected capacity state, not a failed PR. Start AKS through the weekly runner, verify the AKS static agent, then refresh PR checks before any merge decision.
 - Do not print or copy secret values. GitHub, Azure, Jenkins, and observability credentials stay in their configured stores.
 - Public GitHub changes are allowed on Vincent's personal repositories when the automation has clear evidence: update labels, comment, close handled issues, update PR metadata, and merge green mergeable PRs when the change matches the repository policy and checks are passing.
 - Repo-backed GitOps changes are allowed on Vincent's personal repos when they are the right delivery path and the approved Azure-side or OKE-side reconciler will apply them from Git.
@@ -64,11 +65,13 @@ The Codex automation should do the following:
    - Tempo: check whether trace data is visible when a synthetic trace job ran.
    - Rocket.Chat HTTP: when the runner starts AKS, treat an initial `/api/info` failure as startup lag until the bounded retry window expires. Record final HTTP status code and attempt count.
    - Jenkins: verify the Azure AKS static agent separately from the OKE controller. The static `jenkins-static-agent` deployment runs in AKS namespace `jenkins`; it should have Ready pods before Jenkins jobs that target `aks-agent` are treated as healthy.
+   - Jenkins PR checks: if a PR check is `Pending` before AKS starts and targets `aks-agent`, do not classify the PR as blocked. After the runner starts AKS, confirm `jenkins-static-agent` is Ready, then refresh the PR check. Only block or skip the merge if the refreshed check fails, remains pending after the agent is healthy and Jenkins has had time to schedule it, or the diff no longer matches policy.
    - OKE Jenkins controller: verify the controller separately from AKS workload health. Public `/login` should not return a 5xx status, the `jenkins` Argo app should be both `Synced` and `Healthy`, the controller pod should be Ready with service endpoints, and startup logs should not contain plugin dependency failures such as `Failed Loading plugin`, `Update required`, `Failed to load`, or the null `SCM.getKey()` pipeline signature.
    - Jenkins managed jobs: confirm `version-check-rocketchat-k8s` and `security-validation-rocketchat-k8s` render from the managed-jobs configmap with `*/main` and the expected Jenkinsfile paths. Check last-build metadata when Jenkins allows anonymous-safe JSON; otherwise record `auth_required` rather than reading credentials.
 4. Inspect GitHub open issues and PRs:
    - Current known issue: `#113` tracks enabling TLS for operator-managed MongoDB.
    - Current known PR pattern: automated version update PRs should be refreshed before deciding merge readiness.
+   - For PRs whose only blocker is an `aks-agent` Jenkins check while AKS is stopped, start AKS through the runner and refresh checks after the static agent is Ready. Do not leave a PR open merely because CI capacity was offline before the maintenance window.
    - Green, mergeable PRs in Vincent's personal repos may be merged when checks are passing, the diff matches the stated automation policy, and no hard gate is crossed.
    - Issues should be linked to live evidence when possible. Public comments, labels, and closures are allowed on Vincent's personal repos when the evidence supports them.
 5. Check update candidates:

--- a/runbooks/weekly-aks-maintenance.md
+++ b/runbooks/weekly-aks-maintenance.md
@@ -40,6 +40,7 @@ Generated weekly evidence is intentionally ignored by Git. Promote only curated 
 ## Guardrails
 
 - `--execute` is required before the runner can start or stop AKS.
+- If AKS is stopped but the activity log already shows a start/stop this week, the runner will not start it again by default. For a deliberate PR CI unblock window, rerun with `--execute --force-start-when-stopped --shutdown-mode leave-auto` after confirming the cost window is acceptable.
 - Default shutdown mode is `leave-auto`, because Jenkins jobs may still run inside the existing weekday window.
 - Use `--shutdown-mode stop-if-started` only when the weekly run should stop AKS immediately after checks.
 - The runner uses a temporary kubeconfig. It does not overwrite the operator kubeconfig.
@@ -65,13 +66,13 @@ The Codex automation should do the following:
    - Tempo: check whether trace data is visible when a synthetic trace job ran.
    - Rocket.Chat HTTP: when the runner starts AKS, treat an initial `/api/info` failure as startup lag until the bounded retry window expires. Record final HTTP status code and attempt count.
    - Jenkins: verify the Azure AKS static agent separately from the OKE controller. The static `jenkins-static-agent` deployment runs in AKS namespace `jenkins`; it should have Ready pods before Jenkins jobs that target `aks-agent` are treated as healthy.
-   - Jenkins PR checks: if a PR check is `Pending` before AKS starts and targets `aks-agent`, do not classify the PR as blocked. After the runner starts AKS, confirm `jenkins-static-agent` is Ready, then refresh the PR check. Only block or skip the merge if the refreshed check fails, remains pending after the agent is healthy and Jenkins has had time to schedule it, or the diff no longer matches policy.
+   - Jenkins PR checks: if a PR check is `Pending` before AKS starts and targets `aks-agent`, do not classify the PR as blocked. After the runner starts AKS, confirm `jenkins-static-agent` is Ready, then refresh the PR check. If the runner skips start because AKS already had start/stop activity this week, use `--force-start-when-stopped` for the deliberate PR-unblock window instead of leaving the PR stuck on offline CI capacity. Only block or skip the merge if the refreshed check fails, remains pending after the agent is healthy and Jenkins has had time to schedule it, or the diff no longer matches policy.
    - OKE Jenkins controller: verify the controller separately from AKS workload health. Public `/login` should not return a 5xx status, the `jenkins` Argo app should be both `Synced` and `Healthy`, the controller pod should be Ready with service endpoints, and startup logs should not contain plugin dependency failures such as `Failed Loading plugin`, `Update required`, `Failed to load`, or the null `SCM.getKey()` pipeline signature.
    - Jenkins managed jobs: confirm `version-check-rocketchat-k8s` and `security-validation-rocketchat-k8s` render from the managed-jobs configmap with `*/main` and the expected Jenkinsfile paths. Check last-build metadata when Jenkins allows anonymous-safe JSON; otherwise record `auth_required` rather than reading credentials.
 4. Inspect GitHub open issues and PRs:
    - Current known issue: `#113` tracks enabling TLS for operator-managed MongoDB.
    - Current known PR pattern: automated version update PRs should be refreshed before deciding merge readiness.
-   - For PRs whose only blocker is an `aks-agent` Jenkins check while AKS is stopped, start AKS through the runner and refresh checks after the static agent is Ready. Do not leave a PR open merely because CI capacity was offline before the maintenance window.
+   - For PRs whose only blocker is an `aks-agent` Jenkins check while AKS is stopped, start AKS through the runner and refresh checks after the static agent is Ready. If the normal weekly activity gate suppresses a second start, rerun with `--force-start-when-stopped` for the explicit unblock window. Do not leave a PR open merely because CI capacity was offline before the maintenance window.
    - Green, mergeable PRs in Vincent's personal repos may be merged when checks are passing, the diff matches the stated automation policy, and no hard gate is crossed.
    - Issues should be linked to live evidence when possible. Public comments, labels, and closures are allowed on Vincent's personal repos when the evidence supports them.
 5. Check update candidates:

--- a/scripts/weekly_aks_maintenance.py
+++ b/scripts/weekly_aks_maintenance.py
@@ -461,6 +461,7 @@ def write_summary(report_dir: Path, report: dict[str, Any]) -> Path:
         f"- Cluster: `{report['config']['resource_group']}/{report['config']['cluster']}`",
         f"- Mode: `{'execute' if report['config']['execute'] else 'dry-run'}`",
         f"- Shutdown mode: `{report['config']['shutdown_mode']}`",
+        f"- Force start when stopped: `{report['config'].get('force_start_when_stopped', False)}`",
         f"- Started by this run: `{report['aks'].get('started_by_this_run', False)}`",
         f"- Cluster ran this week: `{report['aks'].get('ran_this_week', 'unknown')}`",
         f"- Power state before: `{report['aks'].get('power_state_before', 'unknown')}`",
@@ -483,6 +484,8 @@ def write_summary(report_dir: Path, report: dict[str, Any]) -> Path:
     if report["github"].get("pull_requests"):
         lines.append("- Review open PRs with green checks before any merge decision.")
         lines.append("- If an `aks-agent` Jenkins check was pending while AKS was stopped, refresh it after this run verifies the AKS static agent is Ready before treating the PR as blocked.")
+    if report["aks"].get("start_skipped_reason"):
+        lines.append(f"- AKS start skipped: {report['aks']['start_skipped_reason']}")
     if report["github"].get("issues"):
         lines.append("- Review open issues against live cluster evidence from this run.")
     if report["updates"].get("version_candidates"):
@@ -621,6 +624,15 @@ def main() -> int:
     parser.add_argument("--settle-seconds", type=int, default=int(os.getenv("AKS_MAINTENANCE_SETTLE_SECONDS", "90")))
     parser.add_argument("--http-retry-window", type=int, default=int(os.getenv("AKS_MAINTENANCE_HTTP_RETRY_WINDOW", "300")))
     parser.add_argument("--http-retry-interval", type=int, default=int(os.getenv("AKS_MAINTENANCE_HTTP_RETRY_INTERVAL", "20")))
+    parser.add_argument(
+        "--force-start-when-stopped",
+        action="store_true",
+        help=(
+            "With --execute, start AKS when it is stopped even if this week's "
+            "activity log already shows start/stop activity. Use for deliberate "
+            "PR CI unblock windows after confirming the cost window is acceptable."
+        ),
+    )
     args = parser.parse_args()
 
     stamp = utc_now().strftime("%Y%m%dT%H%M%SZ")
@@ -638,6 +650,7 @@ def main() -> int:
             "timezone": args.timezone,
             "execute": args.execute,
             "shutdown_mode": args.shutdown_mode,
+            "force_start_when_stopped": args.force_start_when_stopped,
         },
         "tools": {},
         "commands": {},
@@ -711,8 +724,14 @@ def main() -> int:
         report["aks"]["activity_event_count"] = len(activity_events) if isinstance(activity_events, list) else 0
         report["aks"]["ran_this_week"] = ran_this_week
         report["aks"]["started_by_this_run"] = False
+        report["aks"]["force_start_when_stopped"] = args.force_start_when_stopped
 
-        if not ran_this_week and power_before.lower() == "stopped":
+        should_start_stopped_cluster = power_before.lower() == "stopped" and (
+            not ran_this_week or args.force_start_when_stopped
+        )
+        if should_start_stopped_cluster:
+            if ran_this_week and args.force_start_when_stopped:
+                report["aks"]["start_gate"] = "forced_after_weekly_activity"
             if args.execute:
                 start = run(
                     ["az", "aks", "start", "--resource-group", args.resource_group, "--name", args.cluster, "--output", "json"],
@@ -746,6 +765,11 @@ def main() -> int:
                     time.sleep(args.settle_seconds)
             else:
                 report["aks"]["would_start"] = True
+        elif power_before.lower() == "stopped" and ran_this_week:
+            report["aks"]["start_skipped_reason"] = (
+                "AKS is stopped, but this week's activity log already contains start/stop activity; "
+                "rerun with --execute --force-start-when-stopped for a deliberate PR CI unblock window."
+            )
 
         show_after = run(
             [

--- a/scripts/weekly_aks_maintenance.py
+++ b/scripts/weekly_aks_maintenance.py
@@ -482,6 +482,7 @@ def write_summary(report_dir: Path, report: dict[str, Any]) -> Path:
     ]
     if report["github"].get("pull_requests"):
         lines.append("- Review open PRs with green checks before any merge decision.")
+        lines.append("- If an `aks-agent` Jenkins check was pending while AKS was stopped, refresh it after this run verifies the AKS static agent is Ready before treating the PR as blocked.")
     if report["github"].get("issues"):
         lines.append("- Review open issues against live cluster evidence from this run.")
     if report["updates"].get("version_candidates"):


### PR DESCRIPTION
## Summary
- document that aks-agent Jenkins PR checks can remain pending while AKS is stopped
- require weekly maintenance to start AKS, verify jenkins-static-agent readiness, then refresh PR checks before treating them as blocked
- add the same reminder to the weekly maintenance runner summary

## Verification
- python3 -m py_compile scripts/weekly_aks_maintenance.py
- git diff --check